### PR TITLE
Add light mode option with toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Not affiliated with OpenAI. Just here to make ChatGPT feel a little cozier.
 * 🌌 **Ambient Aurora background** — a subtle gradient blur behind the ChatGPT interface
 * 👁️ **Chat visibility toggle** — hide/show the chat panel instantly
 * 📝 **Legacy composer option** — switch back to the classic `<textarea>` input instead of the new Lexical composer
+* 🌗 **Light mode** — optional light themed variant with quick toggle
 * 🪄 **Seamless integration** — blends into the UI without breaking layouts or controls
 * 🔒 **Private** — no network calls, no analytics; settings sync via Chrome’s `storage.sync`
 
@@ -40,6 +41,7 @@ This section will be updated once the extension is published on the Chrome Web S
 
 * **Toggle Aurora background**: via the toolbar popup or the in-page controls.
 * **Switch composers**: enable **Legacy composer** from the popup or settings.
+* **Light mode**: flip the "Light mode" toggle in the popup for a brighter vibe.
 * **Settings sync**: changes persist between sessions automatically.
 
 ---

--- a/content.js
+++ b/content.js
@@ -3,7 +3,8 @@
   const ID = 'cgpt-ambient-bg';
   const HTML_CLASS = 'cgpt-ambient-on';
   const LEGACY_CLASS = 'cgpt-legacy-composer';
-  const DEFAULTS = { showInChats: true, legacyComposer: false };
+  const LIGHT_CLASS = 'cgpt-light-mode';
+  const DEFAULTS = { showInChats: true, legacyComposer: false, lightMode: false };
   let settings = { ...DEFAULTS };
 
   const isChatPage = () => location.pathname.startsWith('/c/');
@@ -46,6 +47,7 @@
   function applyRootFlags() {
     document.documentElement.classList.toggle(HTML_CLASS, shouldShow());
     document.documentElement.classList.toggle(LEGACY_CLASS, !!settings.legacyComposer);
+    document.documentElement.classList.toggle(LIGHT_CLASS, !!settings.lightMode);
   }
 
   function showBg() {
@@ -109,6 +111,7 @@
       if (area !== 'sync') return;
       if ('showInChats' in changes) settings.showInChats = changes.showInChats.newValue;
       if ('legacyComposer' in changes) settings.legacyComposer = changes.legacyComposer.newValue;
+      if ('lightMode' in changes) settings.lightMode = changes.lightMode.newValue;
       applyVisibility();
     });
   } else {

--- a/popup.html
+++ b/popup.html
@@ -41,6 +41,14 @@
     </label>
   </div>
 
+  <div class="row">
+    <div class="label">Light mode</div>
+    <label class="switch" title="Use a light themed background">
+      <input type="checkbox" id="lightMode">
+      <span class="track"><span class="thumb"></span></span>
+    </label>
+  </div>
+
   <div class="credit">
     Made by <a href="https://x.com/test_tm7873" target="_blank" rel="noopener noreferrer">@test_tm7873</a> on X
   </div>

--- a/popup.js
+++ b/popup.js
@@ -1,13 +1,15 @@
 // popup.js — controls settings
-const DEFAULTS = { showInChats: true, legacyComposer: false };
+const DEFAULTS = { showInChats: true, legacyComposer: false, lightMode: false };
 
 document.addEventListener('DOMContentLoaded', () => {
   const cbChats = document.getElementById('showInChats');
   const cbLegacy = document.getElementById('legacyComposer');
+  const cbLight = document.getElementById('lightMode');
 
   chrome.storage.sync.get(DEFAULTS, (res) => {
     cbChats.checked  = !!res.showInChats;
     cbLegacy.checked = !!res.legacyComposer;
+    cbLight.checked  = !!res.lightMode;
   });
 
   cbChats.addEventListener('change', () => {
@@ -16,5 +18,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   cbLegacy.addEventListener('change', () => {
     chrome.storage.sync.set({ legacyComposer: cbLegacy.checked });
+  });
+
+  cbLight.addEventListener('change', () => {
+    chrome.storage.sync.set({ lightMode: cbLight.checked });
   });
 });

--- a/sidebar.css
+++ b/sidebar.css
@@ -21,6 +21,12 @@ html.cgpt-ambient-on:not(.cgpt-legacy-composer) #stage-slideover-sidebar {
   }
 }
 
+html.cgpt-ambient-on.cgpt-light-mode:not(.cgpt-legacy-composer) #stage-slideover-sidebar {
+  --glass-bg: rgba(255, 255, 255, 0.28);
+  --glass-stroke: rgba(0, 0, 0, 0.06);
+  --glass-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+}
+
 /* --------- Base sidebar glass (non-legacy only) ---------------------- */
 html.cgpt-ambient-on:not(.cgpt-legacy-composer) #stage-slideover-sidebar {
   position: relative;
@@ -107,6 +113,13 @@ html.cgpt-ambient-on:not(.cgpt-legacy-composer) #stage-slideover-sidebar .tall\:
   }
 }
 
+html.cgpt-ambient-on.cgpt-light-mode:not(.cgpt-legacy-composer) #stage-slideover-sidebar .sticky::before,
+html.cgpt-ambient-on.cgpt-light-mode:not(.cgpt-legacy-composer) #stage-slideover-sidebar .tall\:sticky::before {
+  box-shadow:
+    0 1px 0 rgba(0,0,0,0.06) inset,
+    var(--glass-shadow);
+}
+
 /* --------- Optional polish (non-legacy only) -------------------------- */
 /* Softer hover on glass */
 html.cgpt-ambient-on:not(.cgpt-legacy-composer) #stage-slideover-sidebar .hover\:bg-token-surface-hover:hover,
@@ -126,5 +139,23 @@ html.cgpt-ambient-on:not(.cgpt-legacy-composer) #stage-slideover-sidebar::after 
     to bottom,
     rgba(255,255,255,0.015),
     rgba(0,0,0,0.015)
+  );
+}
+
+@media (prefers-color-scheme: light) {
+  html.cgpt-ambient-on:not(.cgpt-legacy-composer) #stage-slideover-sidebar::after {
+    background: linear-gradient(
+      to bottom,
+      rgba(0,0,0,0.015),
+      rgba(255,255,255,0.015)
+    );
+  }
+}
+
+html.cgpt-ambient-on.cgpt-light-mode:not(.cgpt-legacy-composer) #stage-slideover-sidebar::after {
+  background: linear-gradient(
+    to bottom,
+    rgba(0,0,0,0.015),
+    rgba(255,255,255,0.015)
   );
 }

--- a/styles.css
+++ b/styles.css
@@ -202,3 +202,50 @@ html.cgpt-ambient-on:not(.cgpt-legacy-composer)
   .popover[data-radix-menu-content] .__menu-item:hover {
   background: color-mix(in oklab, currentColor 12%, transparent) !important;
 }
+
+/* =========================================================
+   Light mode overrides
+   ========================================================= */
+
+/* lighten the blurred image and invert gradient emphasis */
+html.cgpt-ambient-on.cgpt-light-mode #cgpt-ambient-bg img {
+  filter: blur(60px) brightness(1.1);
+  opacity: 0.74;
+}
+
+html.cgpt-ambient-on.cgpt-light-mode #cgpt-ambient-bg .haze {
+  background: linear-gradient(
+    to bottom,
+    rgba(0,0,0,0.14) 0%,
+    rgba(0,0,0,0.08) 22%,
+    rgba(0,0,0,0.04) 45%,
+    rgba(0,0,0,0.02) 68%,
+    rgba(0,0,0,0.00) 85%
+  );
+}
+
+html.cgpt-ambient-on.cgpt-light-mode #cgpt-ambient-bg .overlay {
+  background: linear-gradient(
+    to top,
+    rgba(255,255,255,0.90) 0%,
+    rgba(255,255,255,0.70) 18%,
+    rgba(255,255,255,0.45) 36%,
+    rgba(255,255,255,0.20) 60%,
+    rgba(255,255,255,0.00) 80%
+  ) !important;
+}
+
+/* composer glass defaults for forced light mode */
+html.cgpt-ambient-on.cgpt-light-mode:not(.cgpt-legacy-composer)
+  form[data-type="unified-composer"]
+  > div:is(.bg-token-bg-primary, [class*="dark:bg"]) {
+  background: rgba(255,255,255,0.10) !important;
+  border: 1px solid rgba(0,0,0,0.06) !important;
+  box-shadow: 0 6px 26px rgba(0,0,0,.20) !important;
+}
+
+html.cgpt-ambient-on.cgpt-light-mode:not(.cgpt-legacy-composer)
+  .popover.bg-token-main-surface-primary[data-radix-menu-content] {
+  background: rgba(255,255,255,0.28) !important;
+  border-color: rgba(0,0,0,0.06) !important;
+}


### PR DESCRIPTION
## Summary
- add a Light mode toggle to the popup settings
- support light-themed background via new cgpt-light-mode class
- refine light-mode gradients for ambient background and sidebar
- document the new light mode feature

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dd8ccd78832d82d0e953d678c318